### PR TITLE
Add CMake installation statements to some binaries

### DIFF
--- a/dht-server/CMakeLists.txt
+++ b/dht-server/CMakeLists.txt
@@ -12,3 +12,5 @@ set (DHT_SERVER_SOURCE
 
 add_executable (dht-server ${DHT_SERVER_SOURCE})
 target_link_libraries(dht-server tdutils tdactor adnl tl_api dht memprof ${JEMALLOC_LIBRARIES})
+
+install(TARGETS dht-server RUNTIME DESTINATION bin)

--- a/lite-client/CMakeLists.txt
+++ b/lite-client/CMakeLists.txt
@@ -6,3 +6,5 @@ target_link_libraries(lite-client-common PUBLIC tdutils tdactor adnllite tl_api 
 add_executable(lite-client lite-client.cpp lite-client.h)
 target_link_libraries(lite-client tdutils tdactor adnllite tl_api tl_lite_api tl-lite-utils ton_crypto ton_block
   terminal lite-client-common)
+
+install(TARGETS lite-client RUNTIME DESTINATION bin)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -19,3 +19,5 @@ add_executable(pack-viewer pack-viewer.cpp )
 target_link_libraries(pack-viewer tl_api ton_crypto keys validator tddb )
 target_include_directories(pack-viewer PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/..)
+
+install(TARGETS generate-random-id RUNTIME DESTINATION bin)


### PR DESCRIPTION
Added installation statements to ensure installation of following binaries in distribution:
* dht-server
* generate-random-id
* lite-client