### PR TITLE
Fixing error LNK2019: unresolved external symbol _GetProcessMemoryInf…

### DIFF
--- a/tdutils/td/utils/port/Stat.cpp
+++ b/tdutils/td/utils/port/Stat.cpp
@@ -58,6 +58,8 @@
 #define PSAPI_VERSION 1
 #endif
 #include <psapi.h>
+#pragma comment( lib, "psapi.lib" )
+
 
 #endif
 


### PR DESCRIPTION
This fixes the error "LNK2019: unresolved external symbol _GetProcessMemoryInfo@12 referenced in function void __cdecl PrintMemoryInfo(unsigned long) (?PrintMemoryInfo@@YAXK@Z)" when one tries to build windows desktop client.

Psapi.lib is already added to TARGETLIBS and compiles with -DPSAPI_VERSION=1 automatically, however this is not enough.

#pragma comment(lib, "psapi.lib") helps the linker to add the 'psapi.lib' library to the list of library dependencies, as if you had added it in the project properties at Linker->Input->Additional dependencies