### PR TITLE
Fixes compilation error of lite-client on windows

### DIFF
--- a/lite-client/lite-client.cpp
+++ b/lite-client/lite-client.cpp
@@ -3461,7 +3461,7 @@ bool TestNode::ValidatorLoadInfo::store_record(const td::Bits256& key, const blo
   if (it == vset_map.end()) {
     return false;
   }
-  created.at(it->second) = std::make_pair<td::int64, td::int64>(mc_cnt.total, shard_cnt.total);
+  created.at(it->second) = std::make_pair(mc_cnt.total, shard_cnt.total);
   return true;
 }
 


### PR DESCRIPTION
Fixes compilation error:
error C2664: 'std::pair<td::int64,td::int64> std::make_pair<td::int64,td::int64>(_Ty1 &&,_Ty2 &&) noexcept (<expr>)': cannot convert argument 1 from 'const td::uint64' to '_Ty1 &&'

make_pair() has been changed in VS2012 to support a new C++11 feature called move semantics and I suspect that explicitly specifying the types for make_pair() is getting in the way.

The fix should be safe for linux distro as well.