### PR TITLE
Update ccpp-linux.yml

### DIFF
--- a/.github/workflows/ccpp-linux.yml
+++ b/.github/workflows/ccpp-linux.yml
@@ -5,13 +5,12 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
-      with:
-        depth: 1
+      with:      
         submodules: 'recursive'
     - name: Run Cppcheck
       uses: Bedzior/run-cppcheck@master


### PR DESCRIPTION
Soon github actions will use ubuntu 20.04 as latest. Let's avoid surprises and stick to ubuntu-18.04 for now.