### PR TITLE
Adds command line parameter -V that shows build version to the binaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(TON VERSION 0.5 LANGUAGES C CXX)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #set(OPENSSL_USE_STATIC_LIBS TRUE)
 
+ADD_DEFINITIONS( -DBUILD_VERSION=\"3.0.0\" )
+
 # Prevent in-source build
 get_filename_component(TON_REAL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
 get_filename_component(TON_REAL_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" REALPATH)
@@ -112,7 +114,7 @@ add_subdirectory(third-party/crc32c EXCLUDE_FROM_ALL)
 set(CRC32C_FOUND 1)
 
 if (TON_USE_ROCKSDB)
-  if (ANDROID) 
+  if (ANDROID)
     set(PORTABLE ON CACHE BOOL "portable")
   endif()
   set(WITH_GFLAGS OFF CACHE BOOL "build with GFlags")

--- a/adnl/adnl-pong.cpp
+++ b/adnl/adnl-pong.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -96,6 +96,10 @@ int main(int argc, char *argv[]) {
   p.add_option('v', "verbosity", "set verbosity level", [&](td::Slice arg) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
+  });
+  p.add_option('V', "version", "shows adnl-pong build version", [&]() {
+    std::cout << "adnl-pong build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];

--- a/adnl/adnl-proxy.cpp
+++ b/adnl/adnl-proxy.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -302,6 +302,10 @@ int main(int argc, char *argv[]) {
   p.add_option('v', "verbosity", "set verbosity level", [&](td::Slice arg) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
+  });
+  p.add_option('V', "version", "shows adnl-proxy build version", [&]() {
+    std::cout << "adnl-proxy build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];

--- a/create-hardfork/create-hardfork.cpp
+++ b/create-hardfork/create-hardfork.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -262,6 +262,10 @@ int main(int argc, char *argv[]) {
     sb << p;
     std::cout << sb.as_cslice().c_str();
     std::exit(2);
+  });
+  p.add_option('V', "version", "shows create-hardfork build version", [&]() {
+    std::cout << "create-hardfork build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('D', "db", "root for dbs",
                [&](td::Slice fname) { td::actor::send_closure(x, &HardforkCreator::set_db_root, fname.str()); });

--- a/crypto/block/create-state.cpp
+++ b/crypto/block/create-state.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -804,7 +804,8 @@ void usage(const char* progname) {
                "\t-I<source-search-path>\tSets colon-separated library source include path. If not indicated, "
                "$FIFTPATH is used instead.\n"
                "\t-L<library-fif-file>\tPre-loads a library source file\n"
-               "\t-v<verbosity-level>\tSet verbosity level\n";
+               "\t-v<verbosity-level>\tSet verbosity level\n"
+               "\t-V<version>\tShow create-state build version\n";
   std::exit(2);
 }
 
@@ -842,7 +843,7 @@ int main(int argc, char* const argv[]) {
 
   int i;
   int new_verbosity_level = VERBOSITY_NAME(INFO);
-  while (!script_mode && (i = getopt(argc, argv, "hinsI:L:v:")) != -1) {
+  while (!script_mode && (i = getopt(argc, argv, "hinsI:L:v:V")) != -1) {
     switch (i) {
       case 'i':
         interactive = true;
@@ -863,6 +864,10 @@ int main(int argc, char* const argv[]) {
         break;
       case 'v':
         new_verbosity_level = VERBOSITY_NAME(FATAL) + (verbosity = td::to_integer<int>(td::Slice(optarg)));
+        break;
+      case 'V':
+        std::cout << "create-state build version: [" << BUILD_VERSION << "]\n";
+        std::exit(0);
         break;
       case 'h':
       default:

--- a/crypto/block/dump-block.cpp
+++ b/crypto/block/dump-block.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -159,7 +159,7 @@ void test1() {
       std::cout << "    cb = " << cb.finalize() << std::endl;
     }
   }
-  /* 
+  /*
   {
     vm::CellBuilder cb;
     td::BitArray<256> hash;
@@ -246,7 +246,8 @@ td::Status test_vset() {
 void usage() {
   std::cout << "usage: dump-block [-t<typename>][-S][<boc-file>]\n\tor dump-block -h\n\tDumps specified blockchain "
                "block or state "
-               "from <boc-file>, or runs some tests\n\t-S\tDump a blockchain state instead of a block\n";
+               "from <boc-file>, or runs some tests\n\t-S\tDump a blockchain state instead of a block\n"
+               "\t-V<version>\tShow fift build version\n";
   std::exit(2);
 }
 
@@ -259,7 +260,7 @@ int main(int argc, char* const argv[]) {
   bool store_loaded = false;
   int dump = 3;
   auto zerostate = std::make_unique<block::ZerostateInfo>();
-  while ((i = getopt(argc, argv, "CSt:hqv:")) != -1) {
+  while ((i = getopt(argc, argv, "CSt:hqv:V")) != -1) {
     switch (i) {
       case 'C':
         type = &block::gen::t_VmCont;
@@ -279,6 +280,10 @@ int main(int argc, char* const argv[]) {
         vset_compute_test = true;
         store_loaded = true;
         dump = 0;
+        break;
+      case 'V':
+        std::cout << "dump-block build version: [" << BUILD_VERSION << "]\n";
+        std::exit(0);
         break;
       case 'h':
         usage();

--- a/crypto/fift/fift-main.cpp
+++ b/crypto/fift/fift-main.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -65,7 +65,8 @@ void usage(const char* progname) {
                "\t-L<library-fif-file>\tPre-loads a library source file\n"
                "\t-d<ton-db-path>\tUse a ton database\n"
                "\t-s\tScript mode: use first argument as a fift source file and import remaining arguments as $n)\n"
-               "\t-v<verbosity-level>\tSet verbosity level\n";
+               "\t-v<verbosity-level>\tSet verbosity level\n"
+               "\t-V<version>\tShow fift build version\n";
   std::exit(2);
 }
 
@@ -92,7 +93,7 @@ int main(int argc, char* const argv[]) {
 
   int i;
   int new_verbosity_level = VERBOSITY_NAME(INFO);
-  while (!script_mode && (i = getopt(argc, argv, "hinI:L:d:sv:")) != -1) {
+  while (!script_mode && (i = getopt(argc, argv, "hinI:L:d:sv:V")) != -1) {
     switch (i) {
       case 'i':
         interactive = true;
@@ -116,6 +117,11 @@ int main(int argc, char* const argv[]) {
       case 'v':
         new_verbosity_level = VERBOSITY_NAME(FATAL) + td::to_integer<int>(td::Slice(optarg));
         break;
+      case 'V':
+        std::cout << "Fift build version: [" << BUILD_VERSION << "]\n";
+        std::exit(0);
+        break;
+
       case 'h':
       default:
         usage(argv[0]);

--- a/crypto/func/func.cpp
+++ b/crypto/func/func.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -40,9 +40,9 @@ std::ostream* outs = &std::cout;
 std::string generated_from, boc_output_filename;
 
 /*
- * 
+ *
  *   OUTPUT CODE GENERATOR
- * 
+ *
  */
 
 void generate_output_func(SymDef* func_sym) {
@@ -171,7 +171,8 @@ void usage(const char* progname) {
          "-S\tInclude stack layout comments in the output code\n"
          "-R\tInclude operation rewrite comments in the output code\n"
          "-W<output-boc-file>\tInclude Fift code to serialize and save generated code into specified BoC file. Enables "
-         "-A and -P.\n";
+         "-A and -P.\n"
+         "\t-V<version>\tShow func build version\n";
   std::exit(2);
 }
 
@@ -180,7 +181,7 @@ std::string output_filename;
 int main(int argc, char* const argv[]) {
   int i;
   bool interactive = false;
-  while ((i = getopt(argc, argv, "Ahi:Io:O:PRSvW:")) != -1) {
+  while ((i = getopt(argc, argv, "Ahi:Io:O:PRSvW:V")) != -1) {
     switch (i) {
       case 'A':
         funC::asm_preamble = true;
@@ -212,6 +213,10 @@ int main(int argc, char* const argv[]) {
       case 'W':
         funC::boc_output_filename = optarg;
         funC::asm_preamble = funC::program_envelope = true;
+        break;
+      case 'V':
+        std::cout << "Func build version: [" << BUILD_VERSION << "]\n";
+        std::exit(0);
         break;
       case 'h':
       default:

--- a/dht-server/dht-server.cpp
+++ b/dht-server/dht-server.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -1181,6 +1181,10 @@ int main(int argc, char *argv[]) {
   p.add_option('v', "verbosity", "set verbosity level", [&](td::Slice arg) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
+  });
+  p.add_option('V', "version", "shows dht-server build version", [&]() {
+    std::cout << "dht-server build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];

--- a/http/http-proxy.cpp
+++ b/http/http-proxy.cpp
@@ -264,6 +264,10 @@ int main(int argc, char *argv[]) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
   });
+  p.add_option('V', "version", "shows http-proxy build version", [&]() {
+    std::cout << "http-proxy build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
+  });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];
     td::StringBuilder sb(td::MutableSlice{b, 10000});

--- a/lite-client/lite-client.cpp
+++ b/lite-client/lite-client.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -4198,6 +4198,10 @@ int main(int argc, char* argv[]) {
     verbosity = td::to_integer<int>(arg);
     SET_VERBOSITY_LEVEL(VERBOSITY_NAME(FATAL) + verbosity);
     return (verbosity >= 0 && verbosity <= 9) ? td::Status::OK() : td::Status::Error("verbosity must be 0..9");
+  });
+  p.add_option('V', "version", "shows lite-client build version", [&]() {
+    std::cout << "lite-client build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('i', "idx", "set liteserver idx", [&](td::Slice arg) {
     auto idx = td::to_integer<int>(arg);

--- a/rldp-http-proxy/rldp-http-proxy.cpp
+++ b/rldp-http-proxy/rldp-http-proxy.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2019-2020 Telegram Systems LLP
@@ -1132,6 +1132,10 @@ int main(int argc, char *argv[]) {
   p.add_option('v', "verbosity", "set verbosity level", [&](td::Slice arg) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
+  });
+  p.add_option('V', "version", "shows rldp-http-proxy build version", [&]() {
+    std::cout << "rldp-http-proxy build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('h', "help", "prints a help message", [&]() {
     char b[10240];

--- a/tonlib/tonlib/tonlib-cli.cpp
+++ b/tonlib/tonlib/tonlib-cli.cpp
@@ -2308,6 +2308,10 @@ int main(int argc, char* argv[]) {
     SET_VERBOSITY_LEVEL(VERBOSITY_NAME(FATAL) + verbosity);
     return (verbosity >= 0 && verbosity <= 20) ? td::Status::OK() : td::Status::Error("verbosity must be 0..20");
   });
+  p.add_option('V', "version", "show tonlib-cli build version", [&]() {
+    std::cout << "Fift build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
+  });
   p.add_checked_option('C', "config-force", "set lite server config, drop config related blockchain cache",
                        [&](td::Slice arg) {
                          TRY_RESULT(data, td::read_file_str(arg.str()));

--- a/utils/generate-random-id.cpp
+++ b/utils/generate-random-id.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -58,6 +58,10 @@ int main(int argc, char *argv[]) {
     sb << p;
     std::cout << sb.as_cslice().c_str();
     std::exit(2);
+  });
+  p.add_option('V', "version", "shows generate-random-id build version", [&]() {
+    std::cout << "generate-random-id build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('n', "name", "path to save private keys to", [&](td::Slice arg) { name = arg.str(); });
   p.add_checked_option('k', "key", "path to private key to import", [&](td::Slice key) {

--- a/utils/json2tlo.cpp
+++ b/utils/json2tlo.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -51,6 +51,10 @@ int main(int argc, char *argv[]) {
   p.add_option('i', "in", "input", [&](td::Slice key) { in_f = key.str(); });
   p.add_option('o', "out", "output", [&](td::Slice key) { out_f = key.str(); });
   p.add_option('r', "reverse", "read tlo, print json", [&]() { reverse_ = !reverse_; });
+  p.add_option('V', "version", "shows json2tlo build version", [&]() {
+    std::cout << "json2tlo build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
+  });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];
     td::StringBuilder sb(td::MutableSlice{b, 10000});

--- a/validator-engine-console/validator-engine-console.cpp
+++ b/validator-engine-console/validator-engine-console.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -255,6 +255,10 @@ int main(int argc, char* argv[]) {
     sb << p;
     std::cout << sb.as_cslice().c_str();
     std::exit(2);
+  });
+  p.add_option('V', "version", "shows validator-engine-console build version", [&]() {
+    std::cout << "validator-engine-console build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_checked_option('a', "address", "server address", [&](td::Slice arg) {
     td::IPAddress addr;

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of TON Blockchain source code.
 
     TON Blockchain is free software; you can redistribute it and/or
@@ -14,13 +14,13 @@
     You should have received a copy of the GNU General Public License
     along with TON Blockchain.  If not, see <http://www.gnu.org/licenses/>.
 
-    In addition, as a special exception, the copyright holders give permission 
-    to link the code of portions of this program with the OpenSSL library. 
-    You must obey the GNU General Public License in all respects for all 
-    of the code used other than OpenSSL. If you modify file(s) with this 
-    exception, you may extend this exception to your version of the file(s), 
-    but you are not obligated to do so. If you do not wish to do so, delete this 
-    exception statement from your version. If you delete this exception statement 
+    In addition, as a special exception, the copyright holders give permission
+    to link the code of portions of this program with the OpenSSL library.
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the file(s),
+    but you are not obligated to do so. If you do not wish to do so, delete this
+    exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
     Copyright 2017-2020 Telegram Systems LLP
@@ -3285,6 +3285,10 @@ int main(int argc, char *argv[]) {
   p.add_option('v', "verbosity", "set verbosity level", [&](td::Slice arg) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
+  });
+  p.add_option('V', "version", "shows validator-engine build version", [&]() {
+    std::cout << "validator-engine build version: [" << BUILD_VERSION << "]\n";
+    std::exit(0);
   });
   p.add_option('h', "help", "prints_help", [&]() {
     char b[10240];


### PR DESCRIPTION
Build number controlled in top level CMakeLists.txt file via -DBUILD_VERSION variable.
Usage:
adnl-pong -V
validator-engine -V
and so on.

In future CI/CD process updates build version with each release automatically.