### PR TITLE
Fix 'size_t': is not a member of 'td'

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -316,6 +316,7 @@ target_link_libraries(pow-miner PRIVATE ton_crypto ton_block pow-miner-lib)
 
 if (WINGETOPT_FOUND)
   target_link_libraries_system(fift wingetopt)
+  target_link_libraries_system(pow-miner wingetopt)
 endif()
 
 add_library(ton_block ${BLOCK_SOURCE})
@@ -430,6 +431,7 @@ target_include_directories(adjust-block PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT
 target_link_libraries(adjust-block PUBLIC ton_crypto fift-lib ton_block)
 if (WINGETOPT_FOUND)
   target_link_libraries_system(dump-block wingetopt)
+  target_link_libraries_system(adjust-block wingetopt)
 endif()
 
 add_executable(test-weight-distr block/test-weight-distr.cpp)

--- a/rldp2/RldpConnection.cpp
+++ b/rldp2/RldpConnection.cpp
@@ -278,7 +278,7 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
     return;
   }
 
-  auto r_total_size = td::narrow_cast_safe<td::size_t>(part.total_size_);
+  auto r_total_size = td::narrow_cast_safe<std::size_t>(part.total_size_);
   if (r_total_size.is_error()) {
     return;
   }

--- a/storage/LoadSpeed.cpp
+++ b/storage/LoadSpeed.cpp
@@ -22,7 +22,7 @@
 #include "td/utils/format.h"
 
 namespace ton {
-void LoadSpeed::add(td::size_t size, td::Timestamp now) {
+void LoadSpeed::add(std::size_t size, td::Timestamp now) {
   total_size_ += size;
   events_.push(Event{size, now});
   update(now);

--- a/storage/LoadSpeed.h
+++ b/storage/LoadSpeed.h
@@ -26,17 +26,17 @@
 namespace ton {
 class LoadSpeed {
  public:
-  void add(td::size_t size, td::Timestamp now);
+  void add(std::size_t size, td::Timestamp now);
   double speed(td::Timestamp now = td::Timestamp::now()) const;
   friend td::StringBuilder &operator<<(td::StringBuilder &sb, const LoadSpeed &speed);
 
  private:
   struct Event {
-    td::size_t size;
+    std::size_t size;
     td::Timestamp at;
   };
   mutable td::VectorQueue<Event> events_;
-  mutable td::size_t total_size_{0};
+  mutable std::size_t total_size_{0};
 
   double duration() const;
   void update(td::Timestamp now) const;

--- a/storage/MerkleTree.cpp
+++ b/storage/MerkleTree.cpp
@@ -138,7 +138,7 @@ void MerkleTree::init_finish() {
   CHECK(root_hash_);
 }
 
-void MerkleTree::remove_chunk(td::size_t index) {
+void MerkleTree::remove_chunk(std::size_t index) {
   CHECK(index < n_);
   index += n_;
   while (proof_[index].not_null()) {
@@ -147,13 +147,13 @@ void MerkleTree::remove_chunk(td::size_t index) {
   }
 }
 
-bool MerkleTree::has_chunk(td::size_t index) const {
+bool MerkleTree::has_chunk(std::size_t index) const {
   CHECK(index < n_);
   index += n_;
   return proof_[index].not_null();
 }
 
-void MerkleTree::add_chunk(td::size_t index, td::Slice hash) {
+void MerkleTree::add_chunk(std::size_t index, td::Slice hash) {
   CHECK(hash.size() == 32);
   CHECK(index < n_);
   index += n_;

--- a/storage/MerkleTree.h
+++ b/storage/MerkleTree.h
@@ -39,7 +39,7 @@ class MerkleTree {
   MerkleTree(size_t chunks_count, td::Ref<vm::Cell> root_proof);
 
   struct Chunk {
-    td::size_t index{0};
+    std::size_t index{0};
     td::Bits256 hash;
   };
 
@@ -47,7 +47,7 @@ class MerkleTree {
 
   MerkleTree() = default;
   void init_begin(size_t chunks_count);
-  void init_add_chunk(td::size_t index, td::Slice hash);
+  void init_add_chunk(std::size_t index, td::Slice hash);
   void init_finish();
 
   // merge external proof with an existing proof
@@ -70,20 +70,20 @@ class MerkleTree {
 
  private:
   td::uint64 total_blocks_;
-  td::size_t n_;  // n = 2^log_n
+  std::size_t n_;  // n = 2^log_n
   td::uint32 log_n_;
-  td::size_t mark_id_{0};
-  std::vector<td::size_t> mark_;          // n_ * 2
+  std::size_t mark_id_{0};
+  std::vector<std::size_t> mark_;          // n_ * 2
   std::vector<td::Ref<vm::Cell>> proof_;  // n_ * 2
 
   td::optional<td::Bits256> root_hash_;
   td::Ref<vm::Cell> root_proof_;
 
   td::Status validate_proof(td::Ref<vm::Cell> new_root);
-  bool has_chunk(td::size_t index) const;
-  void remove_chunk(td::size_t index);
+  bool has_chunk(std::size_t index) const;
+  void remove_chunk(std::size_t index);
 
-  void add_chunk(td::size_t index, td::Slice hash);
+  void add_chunk(std::size_t index, td::Slice hash);
   void init_proof();
 
   td::Ref<vm::Cell> merge(td::Ref<vm::Cell> root, size_t index);

--- a/storage/storage-cli.cpp
+++ b/storage/storage-cli.cpp
@@ -749,7 +749,7 @@ class StorageCli : public td::actor::Actor {
     auto file_id_str = parser.read_word();
     size_t file_id = std::numeric_limits<size_t>::max();
     if (file_id_str != "*") {
-      TRY_RESULT_PROMISE_ASSIGN(promise, file_id, td::to_integer_safe<td::size_t>(file_id_str));
+      TRY_RESULT_PROMISE_ASSIGN(promise, file_id, td::to_integer_safe<std::size_t>(file_id_str));
     }
     TRY_RESULT_PROMISE(promise, priority, td::to_integer_safe<td::uint8>(parser.read_word()));
     if (priority == 255) {


### PR DESCRIPTION
Following errors were occuring while compiling ton binaries on windows:
\ton\storage\LoadSpeed.h(29,16): error C2039: 'size_t': is not a member of 'td'
\ton\storage\MerkleTree.h(42,9): error C2039: 'size_t': is not a member of 'td'
ton\build\storage\storage.vcxproj

\rldp2\RldpConnection.cpp(281,48): error C2039: 'size_t': is not a member of 'td'
rldp2.vcxproj