### PR TITLE
Update state-serializer.cpp

### DIFF
--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Find & copy binaries
       run: |
         mkdir artifacts
-        cp -R build/crypto/fift build/crypto/adjust-block build/crypto/dump-block build/crypto/tlbc build/crypto/func build/crypto/create-state build/validator-engine-console/validator-engine-console build/tonlib/tonlib-cli build/tonlib/libtonlibjson.0.5.dylib build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
+        rsync -r --exclude 'CMakeFiles' --exclude 'Makefile' --exclude '*.a' --exclude '*.cmake' --exclude 'third-party' --exclude 'test-*' --exclude '*.cc' --exclude '*.json' --exclude '*.txt' build/* artifacts/        
         
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:
-        name: ton-binaries
+        name: ton-macos-binaries
         path: artifacts

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -1,0 +1,45 @@
+name: C/C++ CI macOs-10.15 Compile
+
+on: [push,workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: macos-10.15
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:      
+        submodules: 'recursive'
+    - name: Run Cppcheck
+      uses: Bedzior/run-cppcheck@master
+      with:
+        enabled checks: all
+        enable inconclusive: true
+        generate report: true
+    - name: Upload report
+      uses: actions/upload-artifact@v1
+      with:
+        name: report
+        path: output
+    - name: mkdir
+      run: |
+        mkdir build
+    - name: cmake
+      run: | 
+        cd build
+        cmake ..
+    - name: make -j4
+      run: |
+        cd build
+        make -j4
+    - name: find & copy binaries
+      run: |
+        mkdir artifacts
+        cp --parents build/crypto/fift build/crypto/adjust-block build/crypto/dump-block build/crypto/tlbc build/crypto/func build/crypto/create-state build/validator-engine-console/validator-engine-console build/tonlib/tonlib-cli build/tonlib/libtonlibjson.so.0.5 build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
+    - name: Upload artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: ton-binaries
+        path: artifacts

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -12,17 +12,6 @@ jobs:
       uses: actions/checkout@v2
       with:      
         submodules: 'recursive'
-    - name: Run Cppcheck
-      uses: Bedzior/run-cppcheck@master
-      with:
-        enabled checks: all
-        enable inconclusive: true
-        generate report: true
-    - name: Upload report
-      uses: actions/upload-artifact@v1
-      with:
-        name: report
-        path: output
     - name: mkdir
       run: |
         mkdir build

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -23,12 +23,12 @@ jobs:
     - name: Build TON
       run: |
         rootPath=`pwd`
-        mkdir ton/build
-        cd ton/build
+        mkdir build
+        cd build
         cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
         
-    - name: find & copy binaries
+    - name: Find & copy binaries
       run: |
         mkdir artifacts
         cp --parents build/crypto/fift build/crypto/adjust-block build/crypto/dump-block build/crypto/tlbc build/crypto/func build/crypto/create-state build/validator-engine-console/validator-engine-console build/tonlib/tonlib-cli build/tonlib/libtonlibjson.so.0.5 build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -22,9 +22,10 @@ jobs:
 
     - name: Build TON
       run: |
-        mkdir build
-        cd build
-        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=../openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=../openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
+        rootPath=`pwd`
+        mkdir ton/build
+        cd ton/build
+        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
         
     - name: find & copy binaries

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -17,7 +17,7 @@ jobs:
         git clone https://github.com/openssl/openssl openssl_1_1_1
         cd openssl_1_1_1
         git checkout OpenSSL_1_1_1-stable
-        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=10.12
+        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=10.15
         make build_libs -j4
 
     - name: Build TON
@@ -25,13 +25,13 @@ jobs:
         rootPath=`pwd`
         mkdir build
         cd build
-        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.15 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
         
     - name: Find & copy binaries
       run: |
         mkdir artifacts
-        cp --parents build/crypto/fift build/crypto/adjust-block build/crypto/dump-block build/crypto/tlbc build/crypto/func build/crypto/create-state build/validator-engine-console/validator-engine-console build/tonlib/tonlib-cli build/tonlib/libtonlibjson.so.0.5 build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
+        cp --parents build/crypto/* build/validator-engine-console/validator-engine-console build/tonlib/* build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -5,7 +5,7 @@ on: [push,workflow_dispatch]
 jobs:
   build:
 
-    runs-on: macos-11.0
+    runs-on: macos-10.15
 
     steps:
     - name: Check out repository
@@ -17,7 +17,7 @@ jobs:
         git clone https://github.com/openssl/openssl openssl_1_1_1
         cd openssl_1_1_1
         git checkout OpenSSL_1_1_1-stable
-        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=11.0
+        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=10.15
         make build_libs -j4
 
     - name: Build TON
@@ -25,7 +25,7 @@ jobs:
         rootPath=`pwd`
         mkdir build
         cd build
-        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=11.0 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.15 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
         
     - name: Find & copy binaries

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -12,17 +12,21 @@ jobs:
       uses: actions/checkout@v2
       with:      
         submodules: 'recursive'
-    - name: mkdir
+    - name: Compile OpenSSL
+      run: |
+        git clone https://github.com/openssl/openssl openssl_1_1_1
+        cd openssl_1_1_1
+        git checkout OpenSSL_1_1_1-stable
+        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=10.12
+        make build_libs -j4
+
+    - name: Build TON
       run: |
         mkdir build
-    - name: cmake
-      run: | 
         cd build
-        cmake ..
-    - name: make -j4
-      run: |
-        cd build
+        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=../openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=../openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
+        
     - name: find & copy binaries
       run: |
         mkdir artifacts

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -1,11 +1,11 @@
-name: C/C++ CI macOs-10.15 Compile
+name: C/C++ CI macOS-10.15 Compile
 
 on: [push,workflow_dispatch]
 
 jobs:
   build:
 
-    runs-on: macos-10.15
+    runs-on: macos-11.0
 
     steps:
     - name: Check out repository
@@ -17,7 +17,7 @@ jobs:
         git clone https://github.com/openssl/openssl openssl_1_1_1
         cd openssl_1_1_1
         git checkout OpenSSL_1_1_1-stable
-        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=10.15
+        ./Configure --prefix=/usr/local/macos darwin64-x86_64-cc -static -mmacosx-version-min=11.0
         make build_libs -j4
 
     - name: Build TON
@@ -25,7 +25,7 @@ jobs:
         rootPath=`pwd`
         mkdir build
         cd build
-        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.15 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOPENSSL_FOUND=1 -DOPENSSL_INCLUDE_DIR=$rootPath/openssl_1_1_1/include -DOPENSSL_CRYPTO_LIBRARY=$rootPath/openssl_1_1_1/libcrypto.a -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=11.0 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_BUILD_TYPE=Release ..
         make -j4
         
     - name: Find & copy binaries

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Find & copy binaries
       run: |
         mkdir artifacts
-        cp --parents build/crypto/* build/validator-engine-console/validator-engine-console build/tonlib/* build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
+        cp --parents build/* artifacts
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Find & copy binaries
       run: |
         mkdir artifacts
-        cp -R build/* artifacts
+        cp -R build/crypto/fift build/crypto/adjust-block build/crypto/dump-block build/crypto/tlbc build/crypto/func build/crypto/create-state build/validator-engine-console/validator-engine-console build/tonlib/tonlib-cli build/tonlib/libtonlibjson.0.5.dylib build/tddb/io-bench build/http/http-proxy build/tdnet/udp_ping_pong build/tdnet/tcp_ping_pong build/rldp-http-proxy/rldp-http-proxy build/dht-server/dht-server build/lite-client/lite-client build/validator-engine/validator-engine build/utils/generate-random-id build/utils/pack-viewer build/utils/json2tlo build/adnl/adnl-proxy build/adnl/adnl-pong artifacts
+        
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Find & copy binaries
       run: |
         mkdir artifacts
-        cp --parents build/* artifacts
+        cp -R build/* artifacts
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/validator/state-serializer.cpp
+++ b/validator/state-serializer.cpp
@@ -155,7 +155,7 @@ void AsyncStateSerializer::next_iteration() {
 
 void AsyncStateSerializer::got_top_masterchain_handle(BlockIdExt block_id) {
   if (masterchain_handle_ && masterchain_handle_->id().id.seqno < block_id.id.seqno) {
-    CHECK(masterchain_handle_->inited_next_left());
+    // CHECK(masterchain_handle_->inited_next_left());
   }
 }
 


### PR DESCRIPTION
In a non-hardfoked TON blockchain stateserializermasterchainseqno should be less than or equal to shardclientmasterchainseqno.

stateserializermasterchainseqno parameter normally increases automatically together with shardclientmasterchainseqno and never becomes greater than shardclientmasterchainseqno, however once we do a hardfork we force validator to start mining from some block in the past plus one block (generated by create-hardfork utility) atop of it. This leads to the situation when stateserializermasterchainseqno becomes greater than shardclientmasterchainseqno.

Strange though, on start the hardforked node does not fail and mines the blocks without any problems. Only some time later when stateserializermasterchainseqno
becomes equal to shardclientmasterchainseqno all hardforked nodes fail with error:
state_serializer.cpp:155 masterchain_handle_->inited_next_left()

This patch removes comparison check between serialized state masterchain seqno from pre-hardforked node and current shard seqno from hardforked node.

Values of stateserializermasterchainseqno and shardclientmasterchainseqno can be found via command:
validator-engine-console -k client -p server.pub -v 0 -a IP:CONSOLE_PORT -rc getstats

Interestingly if you look at the current hardforked testnet2 and execute getstats, you will notice that stateserializermasterchainseqno is set to 0. This is probably another way how to cheat the commented out check proposed by this pull request.