### PR TITLE
Update state-serializer.cpp

### DIFF
--- a/validator/state-serializer.cpp
+++ b/validator/state-serializer.cpp
@@ -155,7 +155,7 @@ void AsyncStateSerializer::next_iteration() {
 
 void AsyncStateSerializer::got_top_masterchain_handle(BlockIdExt block_id) {
   if (masterchain_handle_ && masterchain_handle_->id().id.seqno < block_id.id.seqno) {
-    CHECK(masterchain_handle_->inited_next_left());
+    // CHECK(masterchain_handle_->inited_next_left());
   }
 }
 


### PR DESCRIPTION
In a non-hardfoked TON blockchain stateserializermasterchainseqno should be less than or equal to shardclientmasterchainseqno.

stateserializermasterchainseqno parameter normally increases automatically together with shardclientmasterchainseqno and never becomes greater than shardclientmasterchainseqno, however once we do a hardfork we force validator to start mining from some block in the past plus one block (generated by create-hardfork utility) atop of it. This leads to the situation when stateserializermasterchainseqno becomes greater than shardclientmasterchainseqno.

Strange though, on start the hardforked node does not fail and mines the blocks without any problems. Only some time later when stateserializermasterchainseqno
becomes equal to shardclientmasterchainseqno all hardforked nodes fail with error:
state_serializer.cpp:155 masterchain_handle_->inited_next_left()

This patch removes comparison check between serialized state masterchain seqno from pre-hardforked node and current shard seqno from hardforked node.

Values of stateserializermasterchainseqno and shardclientmasterchainseqno can be found via command:
validator-engine-console -k client -p server.pub -v 0 -a IP:CONSOLE_PORT -rc getstats

Interestingly if you look at the current hardforked testnet2 and execute getstats, you will notice that stateserializermasterchainseqno is set to 0. 
This is probably another way how to cheat the commented out check proposed by this pull request.