### PR TITLE
Adding support to apple-m1 arthitectecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,15 @@ option(TONLIB_ENABLE_JNI "Use \"ON\" to enable JNI-compatible TonLib API.")
 option(TON_USE_ASAN "Use \"ON\" to enable AddressSanitizer." OFF)
 option(TON_USE_TSAN "Use \"ON\" to enable ThreadSanitizer." OFF)
 option(TON_USE_UBSAN "Use \"ON\" to enable UndefinedBehaviorSanitizer." OFF)
-set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
+
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+set(TON_ARCH "native")
+
+if (ARCHITECTURE MATCHES "arm64")
+    set(TON_ARCH "apple-m1")
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
 
 if (TON_USE_ABSEIL)
   message("Add abseil-cpp")
@@ -204,7 +212,7 @@ find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
 if (TON_ARCH AND NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${TON_ARCH}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")
 endif()
 if (THREADS_HAVE_PTHREAD_ARG)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,8 @@ option(TONLIB_ENABLE_JNI "Use \"ON\" to enable JNI-compatible TonLib API.")
 option(TON_USE_ASAN "Use \"ON\" to enable AddressSanitizer." OFF)
 option(TON_USE_TSAN "Use \"ON\" to enable ThreadSanitizer." OFF)
 option(TON_USE_UBSAN "Use \"ON\" to enable UndefinedBehaviorSanitizer." OFF)
-
+set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
-set(TON_ARCH "native")
 
 if (ARCHITECTURE MATCHES "arm64")
     set(TON_ARCH "apple-m1")


### PR DESCRIPTION
This PR include two parts 
1. detecting arm based apple devices and passing the right value to clang complier
2. changing the clang flag from march to **mcpu** and pass the right flag based on the system architecture, in case of an apple arm based processor we are passing **-mcpu=apple-m1** 

Tested on apple both arm and non arm cpus