### PR TITLE
Add base64 key input parameter to LiteClient

### DIFF
--- a/lite-client/lite-client.cpp
+++ b/lite-client/lite-client.cpp
@@ -4261,6 +4261,8 @@ int main(int argc, char* argv[]) {
   });
   p.add_option('p', "pub", "remote public key",
                [&](td::Slice arg) { td::actor::send_closure(x, &TestNode::set_public_key, td::BufferSlice{arg}); });
+  p.add_option('b', "b64", "remote public key as base64",
+               [&](td::Slice arg) { td::actor::send_closure(x, &TestNode::decode_public_key, td::BufferSlice{arg}); });
   p.add_option('d', "daemonize", "set SIGHUP", [&]() {
     td::set_signal_handler(td::SignalType::HangUp, [](int sig) {
 #if TD_DARWIN || TD_LINUX

--- a/lite-client/lite-client.h
+++ b/lite-client/lite-client.h
@@ -394,6 +394,18 @@ class TestNode : public td::actor::Actor {
     }
     remote_public_key_ = R.move_as_ok();
   }
+  void decode_public_key(td::BufferSlice b64_key) {
+    auto R = [&]() -> td::Result<ton::PublicKey> {
+      std::string key_bytes = {(char)0xc6, (char)0xb4, (char)0x13, (char)0x48};
+      key_bytes = key_bytes + td::base64_decode(b64_key.as_slice().str()).move_as_ok();
+      return ton::PublicKey::import(key_bytes);
+    }();
+
+    if (R.is_error()) {
+      LOG(FATAL) << "bad b64 server public key: " << R.move_as_error();
+    }
+    remote_public_key_ = R.move_as_ok();
+  }
   void set_fail_timeout(td::Timestamp ts) {
     fail_timeout_ = ts;
     alarm_timestamp().relax(fail_timeout_);


### PR DESCRIPTION
This PR adds a `-b | --b64` argument to `lite-client`, this argument expects a truncated base64 representation of Lite Server public key which is the same value as stored in network / wallet configuration files. 

With addition of such parameter connections to lite servers can be performed without any support files (such as configs or key files), this is very useful for scripting purposes, in particular when many lite servers must be accessible. For example monitoring systems.