### PR TITLE
Adjust limits for tonlib library request and search

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -3478,7 +3478,7 @@ td::Result<vm::StackEntry> from_tonlib_api(tonlib_api::tvm_StackEntry& entry) {
 
 void deep_library_search(std::set<td::Bits256>& set, std::set<vm::Cell::Hash>& visited,
                          vm::Dictionary libs, td::Ref<vm::Cell> cell, int depth) {
-  if (depth <= 0 || set.size() >= 127 || visited.size() >= 1000) {
+  if (depth <= 0 || set.size() >= 16 || visited.size() >= 256) {
     return;
   }
   auto ins = visited.insert(cell->get_hash());
@@ -3540,7 +3540,7 @@ td::Status TonlibClient::do_request(const tonlib_api::smc_runGetMethod& request,
     if (code.not_null()) {
       std::set<td::Bits256> librarySet;
       std::set<vm::Cell::Hash> visited;
-      deep_library_search(librarySet, visited, self->libraries, code, 20);
+      deep_library_search(librarySet, visited, self->libraries, code, 24);
       std::vector<td::Bits256> libraryList{librarySet.begin(), librarySet.end()};
       if (libraryList.size() > 0) {
         LOG(DEBUG) << "Requesting found libraries in code (" << libraryList.size() << ")";

--- a/validator/impl/liteserver.cpp
+++ b/validator/impl/liteserver.cpp
@@ -748,9 +748,9 @@ void LiteQuery::perform_runSmcMethod(BlockIdExt blkid, WorkchainId workchain, St
 
 void LiteQuery::perform_getLibraries(std::vector<td::Bits256> library_list) {
   LOG(INFO) << "started a getLibraries(<list of " << library_list.size() << " parameters>) liteserver query";
-  if (library_list.size() > 127) {
-    LOG(INFO) << "too many libraries requested, returning only first 127";
-    library_list.resize(127);
+  if (library_list.size() > 16) {
+    LOG(INFO) << "too many libraries requested, returning only first 16";
+    library_list.resize(16);
   }
   sort( library_list.begin(), library_list.end() );
   library_list.erase( unique( library_list.begin(), library_list.end() ), library_list.end() );


### PR DESCRIPTION
Adjust limits to prevent theoretical DoS accounts accounting for practical existing complex contracts