### PR TITLE
Fix IF:<{ and IFNOT:<{ empty continuation case

### DIFF
--- a/crypto/fift/lib/Asm.fif
+++ b/crypto/fift/lib/Asm.fif
@@ -689,9 +689,9 @@ x{E30F} @Defop(ref*2) IFREFELSEREF
   [] execute
 } : @run-cont-op
 { triple 1 ' @run-cont-op does create } : @def-cont-op
-{ } { PUSHCONT IF } { IFREF } @def-cont-op IF-cont
+{ DROP } { PUSHCONT IF } { IFREF } @def-cont-op IF-cont
 { IFRET } { PUSHCONT IFJMP } { IFJMPREF } @def-cont-op IFJMP-cont
-{ } { PUSHCONT IFNOT } { IFNOTREF } @def-cont-op IFNOT-cont
+{ DROP } { PUSHCONT IFNOT } { IFNOTREF } @def-cont-op IFNOT-cont
 { IFNOTRET } { PUSHCONT IFNOTJMP } { IFNOTJMPREF } @def-cont-op IFNOTJMP-cont
 { dup 2over rot } : 3dup
 


### PR DESCRIPTION
The boolean value should be DROPped in the case the continuation is empty.

To reproduce the bug, you can compare the following fift-assembler programs 

```
"Asm.fif" include
<{ 42 PUSHINT IF:<{ }> }>s runvmcode .s // leaves 42 0
```
and 
```
"Asm.fif" include
<{ 42 PUSHINT IF:<{ NOP }> }>s runvmcode .s // leaves 0
```
which obviously should be equivalent.

In some cases FunC compiler indeed produces empty IF:<{ branches, for example consider the following code
```
int main(int x) {
  int a = 1;
  if (x) { int a = 2; }
  return a;
}
```
which compiles into 
```
main PROC:<{
  //  x
  1 PUSHINT	//  x a=1
  SWAP	//  a=1 x
  IF:<{	//  a=1
  }>	//  a=1
}>
```
(the bug was actually met in such situation)