### PR TITLE
Fix tvm_stackEntrySlice in from_tonlib_api

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -3440,7 +3440,8 @@ td::Result<vm::StackEntry> from_tonlib_api(tonlib_api::tvm_StackEntry& entry) {
           [&](tonlib_api::tvm_stackEntryUnsupported& cell) { return td::Status::Error("Unsuppored stack entry"); },
           [&](tonlib_api::tvm_stackEntrySlice& cell) -> td::Result<vm::StackEntry> {
             TRY_RESULT(res, vm::std_boc_deserialize(cell.slice_->bytes_));
-            return vm::StackEntry{std::move(res)};
+            auto slice = vm::load_cell_slice_ref(std::move(res));
+            return vm::StackEntry{std::move(slice)};
           },
           [&](tonlib_api::tvm_stackEntryCell& cell) -> td::Result<vm::StackEntry> {
             TRY_RESULT(res, vm::std_boc_deserialize(cell.cell_->bytes_));


### PR DESCRIPTION
After using `tvm.stackEntrySlice` as input in `smc.runGetMethod`it converts slice into cell via `from_tonlib_api` method.

Because of `vm::std_boc_deserialize(cell.slice_->bytes_)` write `Ref<Cell>` into `res` variable.

So the solution is to convert cell into slice.

To test before / after you can use `kQBwy09Ifnqnx6J7KiWTe9cgjB7Djaefyk3ZIugotC3JI-f3` smart contract in mainnet.

The code of method is pretty easy:

```
slice load_slice_address(slice address) method_id {
    return address~load_msg_addr();
}
```

So if you run this get method via tonlibjson api:

(bytes is boc serialized address here)


```
{
    '@type': 'smc.runGetMethod',
    "id": 1,
    'method': {'@type': 'smc.methodIdName', 'name': "load_slice_address"},
    'stack': [
        {'@type': 'tvm.stackEntrySlice', 'slice': 
             {'@type': 'tvm.Slice', 
              'bytes': "te6cckEBAQEAJAAAQ4AO/X4j7EYrBivlP7mKTC/WrYGgrPAPXLJpvRfhBrH3MBA1pbog"
             }}
    ]
}
```

Without fix it will return:

```
{
  "@type": "smc.runResult",
  "gas_used": 462,
  "stack": [
    {
      "@type": "tvm.stackEntryNumber",
      "number": {
        "@type": "tvm.numberDecimal",
        "number": "0"
      }
    }
  ],
  "exit_code": 7,
  "@extra": "1650178162.1816163:0.39559018188178896"
}
```


After fix:

```
{
  "@type": "smc.runResult",
  "gas_used": 435,
  "stack": [
    {
      "@type": "tvm.stackEntryCell",
      "cell": {
        "@type": "tvm.cell",
        "bytes": "te6cckEBAQEAJAAAQ4AO/X4j7EYrBivlP7mKTC/WrYGgrPAPXLJpvRfhBrH3MBA1pbog"
      }
    }
  ],
  "exit_code": 0,
  "@extra": "1650177890.645042:0.9260577380833197"
}
```

